### PR TITLE
Add minimal FastAPI web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,3 +391,14 @@ docker run -it -e OPENAI_API_KEY=$OPENAI_API_KEY \
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=SakanaAI/AI-Scientist&type=Date)](https://star-history.com/#SakanaAI/AI-Scientist&Date)
+
+## Web Interface
+A minimal FastAPI server is provided under `web_app/`. Build the Docker image and run it to access a browser-based interface:
+
+```bash
+docker build -f web_app/Dockerfile -t ai-scientist-web .
+docker run -p 8000:8000 -e OPENAI_API_KEY=$OPENAI_API_KEY ai-scientist-web
+```
+
+Open `http://localhost:8000/docs` to access the API documentation.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,9 @@ datasets
 tiktoken
 wandb
 tqdm
+fastapi
+uvicorn
+sqlalchemy
+aiosqlite
+python-multipart
+jinja2

--- a/web_app/Dockerfile
+++ b/web_app/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt /app/
+COPY web_app/requirements.txt /app/web_app/
+RUN pip install --no-cache-dir -r requirements.txt && pip install --no-cache-dir -r web_app/requirements.txt
+COPY . /app
+EXPOSE 8000
+CMD ["uvicorn", "web_app.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/web_app/app.py
+++ b/web_app/app.py
@@ -1,0 +1,79 @@
+import os
+import subprocess
+import uuid
+from fastapi import FastAPI, UploadFile, File, HTTPException, BackgroundTasks
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+
+from .db import SessionLocal, init_db
+from .models import Run, RunStatus
+
+app = FastAPI()
+init_db()
+
+RUNS_DIR = os.path.join(os.getcwd(), 'web_runs')
+os.makedirs(RUNS_DIR, exist_ok=True)
+
+processes = {}
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def launch_run(run_id: int, run_dir: str, params: dict):
+    cmd = [
+        'python', 'launch_scientist.py',
+        '--model', params['model_name'],
+        '--experiment', params['experiment_name'],
+        '--num-ideas', str(params['num_ideas'])
+    ]
+    with open(os.path.join(run_dir, 'stdout.log'), 'w') as out, \
+         open(os.path.join(run_dir, 'stderr.log'), 'w') as err:
+        proc = subprocess.Popen(cmd, stdout=out, stderr=err)
+    processes[run_id] = proc
+
+@app.post('/runs/')
+async def create_run(model_name: str, experiment_name: str, num_ideas: int, background_tasks: BackgroundTasks):
+    db: Session = next(get_db())
+    run = Run(model_name=model_name, experiment_name=experiment_name, num_ideas=num_ideas, template_slug=experiment_name)
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    run_dir = os.path.join(RUNS_DIR, str(run.id))
+    os.makedirs(run_dir, exist_ok=True)
+    background_tasks.add_task(launch_run, run.id, run_dir, {
+        'model_name': model_name,
+        'experiment_name': experiment_name,
+        'num_ideas': num_ideas
+    })
+    run.status = RunStatus.RUNNING
+    db.commit()
+    return {'run_id': run.id}
+
+@app.get('/runs/{run_id}/status')
+async def run_status(run_id: int):
+    db: Session = next(get_db())
+    run = db.get(Run, run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail='Run not found')
+    proc = processes.get(run_id)
+    if proc and proc.poll() is None:
+        run.status = RunStatus.RUNNING
+    elif proc and proc.poll() == 0:
+        run.status = RunStatus.SUCCESS
+    elif proc and proc.poll() is not None:
+        run.status = RunStatus.FAILED
+    db.commit()
+    return {'status': run.status}
+
+@app.get('/runs/{run_id}/log')
+async def get_log(run_id: int):
+    log_file = os.path.join(RUNS_DIR, str(run_id), 'stdout.log')
+    if os.path.exists(log_file):
+        return FileResponse(log_file, media_type='text/plain')
+    raise HTTPException(status_code=404, detail='Log not found')

--- a/web_app/db.py
+++ b/web_app/db.py
@@ -1,0 +1,13 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = 'sqlite:///ai_scientist.db'
+
+engine = create_engine(DATABASE_URL, connect_args={'check_same_thread': False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/web_app/models.py
+++ b/web_app/models.py
@@ -1,0 +1,23 @@
+import enum
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime, Enum, Text
+from .db import Base
+
+class RunStatus(str, enum.Enum):
+    PENDING = 'PENDING'
+    RUNNING = 'RUNNING'
+    SUCCESS = 'SUCCESS'
+    FAILED = 'FAILED'
+
+class Run(Base):
+    __tablename__ = 'runs'
+    id = Column(Integer, primary_key=True, index=True)
+    status = Column(Enum(RunStatus), default=RunStatus.PENDING)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    model_name = Column(String)
+    experiment_name = Column(String)
+    num_ideas = Column(Integer)
+    template_slug = Column(String)
+    output_directory = Column(String)
+    error_message = Column(Text)

--- a/web_app/requirements.txt
+++ b/web_app/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+aiosqlite
+python-multipart
+jinja2


### PR DESCRIPTION
## Summary
- add basic FastAPI app under `web_app/`
- create SQLite models for tracking runs
- provide Dockerfile and requirements for the web server
- document web usage in README

## Testing
- `python -m py_compile web_app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c17d37908328b54c762812b43abd