### PR TITLE
Add FastAPI web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,25 @@ docker run -it -e OPENAI_API_KEY=$OPENAI_API_KEY \
   <AI_SCIENTIST_IMAGE>
 ```
 
+## Web Interface
+
+A simple FastAPI web interface is provided in `web_app/`. You can build an image
+with the web server enabled using the separate Dockerfile:
+
+```bash
+docker build -f experimental/Dockerfile.web -t ai-scientist-web .
+```
+
+Run the container and expose the port to your host:
+
+```bash
+docker run -p 8000:8000 -e OPENAI_API_KEY=$OPENAI_API_KEY ai-scientist-web
+```
+
+The UI lets you start new runs, upload template files and monitor results. API
+keys are supplied as environment variables in the same way as for the command
+line interface.
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=SakanaAI/AI-Scientist&type=Date)](https://star-history.com/#SakanaAI/AI-Scientist&Date)

--- a/experimental/Dockerfile.web
+++ b/experimental/Dockerfile.web
@@ -1,0 +1,16 @@
+FROM python:3.11-bullseye
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends texlive-full && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+COPY . /app/AI-Scientist
+WORKDIR /app/AI-Scientist
+
+EXPOSE 8000
+CMD ["uvicorn", "web_app.app:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ datasets
 tiktoken
 wandb
 tqdm
+fastapi
+uvicorn
+sqlalchemy

--- a/web_app/app.py
+++ b/web_app/app.py
@@ -1,0 +1,160 @@
+import os
+import subprocess
+import datetime
+import shutil
+from threading import Thread
+
+from fastapi import FastAPI, BackgroundTasks, UploadFile, File, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, FileResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.environ.get("AI_SCIENTIST_DB", "sqlite:///web_app.db")
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class Run(Base):
+    __tablename__ = "runs"
+    id = Column(Integer, primary_key=True, index=True)
+    experiment = Column(String)
+    model = Column(String)
+    num_ideas = Column(Integer)
+    status = Column(String, default="running")
+    output_path = Column(String)
+    start_time = Column(DateTime, default=datetime.datetime.utcnow)
+    end_time = Column(DateTime)
+
+class Idea(Base):
+    __tablename__ = "ideas"
+    id = Column(Integer, primary_key=True, index=True)
+    run_id = Column(Integer)
+    name = Column(String)
+    status = Column(String)
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+templates = Jinja2Templates(directory="web_app/templates")
+
+
+def run_scientist_task(run_id: int, experiment: str, model: str, num_ideas: int):
+    session = SessionLocal()
+    run = session.get(Run, run_id)
+    output_path = os.path.join("results", experiment)
+    run.output_path = output_path
+    session.commit()
+    os.makedirs(output_path, exist_ok=True)
+    log_file = os.path.join(output_path, f"run_{run_id}.log")
+    cmd = [
+        "python",
+        "launch_scientist.py",
+        "--model",
+        model,
+        "--experiment",
+        experiment,
+        "--num-ideas",
+        str(num_ideas),
+    ]
+    with open(log_file, "w") as log_f:
+        process = subprocess.Popen(cmd, stdout=log_f, stderr=subprocess.STDOUT)
+        process.wait()
+    run.status = "completed" if process.returncode == 0 else "failed"
+    run.end_time = datetime.datetime.utcnow()
+    session.commit()
+    session.close()
+
+
+def spawn_task(run_id: int, experiment: str, model: str, num_ideas: int):
+    thread = Thread(target=run_scientist_task, args=(run_id, experiment, model, num_ideas))
+    thread.daemon = True
+    thread.start()
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    session = SessionLocal()
+    runs = session.query(Run).order_by(Run.id.desc()).all()
+    session.close()
+    return templates.TemplateResponse("index.html", {"request": request, "runs": runs})
+
+
+@app.post("/runs/start")
+async def start_run(
+    background_tasks: BackgroundTasks,
+    model: str = Form(...),
+    experiment: str = Form(...),
+    num_ideas: int = Form(1),
+):
+    session = SessionLocal()
+    run = Run(experiment=experiment, model=model, num_ideas=num_ideas, status="running")
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+    session.close()
+    background_tasks.add_task(spawn_task, run.id, experiment, model, num_ideas)
+    return {"run_id": run.id}
+
+
+@app.get("/api/runs/{run_id}")
+def api_run_status(run_id: int):
+    session = SessionLocal()
+    run = session.get(Run, run_id)
+    if not run:
+        session.close()
+        raise HTTPException(status_code=404, detail="Run not found")
+    data = {
+        "id": run.id,
+        "experiment": run.experiment,
+        "model": run.model,
+        "num_ideas": run.num_ideas,
+        "status": run.status,
+        "start_time": run.start_time,
+        "end_time": run.end_time,
+    }
+    session.close()
+    return data
+
+
+@app.get("/runs/{run_id}", response_class=HTMLResponse)
+def run_detail(run_id: int, request: Request):
+    session = SessionLocal()
+    run = session.get(Run, run_id)
+    if not run:
+        session.close()
+        raise HTTPException(status_code=404, detail="Run not found")
+    files = []
+    if run.output_path and os.path.exists(run.output_path):
+        files = os.listdir(run.output_path)
+    session.close()
+    return templates.TemplateResponse(
+        "run.html", {"request": request, "run": run, "files": files}
+    )
+
+
+@app.get("/results/{run_id}/{file_name}")
+def get_result_file(run_id: int, file_name: str):
+    session = SessionLocal()
+    run = session.get(Run, run_id)
+    if not run:
+        session.close()
+        raise HTTPException(status_code=404, detail="Run not found")
+    file_path = os.path.join(run.output_path, file_name)
+    session.close()
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_path)
+
+
+@app.post("/templates/upload")
+async def upload_template(
+    experiment: str = Form(...), file: UploadFile = File(...)
+):
+    dest = os.path.join("templates", experiment, file.filename)
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    with open(dest, "wb") as f:
+        shutil.copyfileobj(file.file, f)
+    return {"status": "uploaded"}
+

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>AI Scientist Web</title>
+</head>
+<body>
+<h1>AI Scientist Web</h1>
+
+<h2>Start New Run</h2>
+<form action="/runs/start" method="post">
+    Model: <input type="text" name="model" value="gpt-4o-2024-05-13"><br>
+    Experiment: <input type="text" name="experiment" value="nanoGPT_lite"><br>
+    Num Ideas: <input type="number" name="num_ideas" value="1"><br>
+    <input type="submit" value="Start">
+</form>
+
+<h2>Upload Template</h2>
+<form action="/templates/upload" method="post" enctype="multipart/form-data">
+    Experiment Name: <input type="text" name="experiment"><br>
+    File: <input type="file" name="file"><br>
+    <input type="submit" value="Upload">
+</form>
+
+<h2>Runs</h2>
+<ul>
+{% for run in runs %}
+    <li><a href="/runs/{{ run.id }}">Run {{ run.id }} - {{ run.experiment }} - {{ run.status }}</a></li>
+{% endfor %}
+</ul>
+</body>
+</html>

--- a/web_app/templates/run.html
+++ b/web_app/templates/run.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Run {{ run.id }}</title>
+</head>
+<body>
+<h1>Run {{ run.id }}</h1>
+<p>Status: {{ run.status }}</p>
+<ul>
+{% for file in files %}
+    <li><a href="/results/{{ run.id }}/{{ file }}">{{ file }}</a></li>
+{% endfor %}
+</ul>
+<a href="/">Back</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement FastAPI app under `web_app/`
- create minimal HTML templates
- add Dockerfile for running the web server
- document web interface usage in README
- add FastAPI dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840cc42da9c8328ab49d95b7f2c8234